### PR TITLE
fix: fix astroid version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = [
     "linter",
     "flakehell",
 ]
-dependencies = ["astroid"]
+dependencies = ["astroid>=2.15,<3"]
 
 [project.optional-dependencies]
 test = ["pytest"]


### PR DESCRIPTION
Astroid 3.0.0 brokes flake8-warning with error: 
```python
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py", line 188, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py", line 147, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/private/tmp/flake8-warnings/flake8_warnings/__init__.py", line 4, in <module>
    from ._flake8_plugin import Flake8Checker
  File "/private/tmp/flake8-warnings/flake8_warnings/_flake8_plugin.py", line 6, in <module>
    from ._finder import WarningFinder
  File "/private/tmp/flake8-warnings/flake8_warnings/_finder.py", line 10, in <module>
    from ._extractors import EXTRACTORS, Extractor, WarningInfo
  File "/private/tmp/flake8-warnings/flake8_warnings/_extractors/__init__.py", line 7, in <module>
    from ._warnings import WarningsExtractor
  File "/private/tmp/flake8-warnings/flake8_warnings/_extractors/_warnings.py", line 11, in <module>
    astroid.TryExcept,
AttributeError: module 'astroid' has no attribute 'TryExcept'
```

Binding 2.x version solves issue